### PR TITLE
Improve date scoring brackets for month-level guesses

### DIFF
--- a/bot/services/scoring_service.py
+++ b/bot/services/scoring_service.py
@@ -7,6 +7,9 @@ def calculate_time_score(guessed_timestamp_ms: int, actual_timestamp_ms: int) ->
     """Calculate score based on time accuracy.
 
     Returns 0-500 points based on how close the guess is to the actual time.
+
+    Scoring brackets are designed to be fair for "Month Year" format guesses,
+    where guessing one month off should still give a reasonable score.
     """
     # Calculate difference in days
     diff_ms = abs(guessed_timestamp_ms - actual_timestamp_ms)
@@ -15,12 +18,14 @@ def calculate_time_score(guessed_timestamp_ms: int, actual_timestamp_ms: int) ->
     if diff_days <= 1:
         return 500
     elif diff_days <= 7:
+        return 450
+    elif diff_days <= 31:
         return 400
-    elif diff_days <= 30:
+    elif diff_days <= 62:
         return 300
-    elif diff_days <= 90:
+    elif diff_days <= 93:
         return 200
-    elif diff_days <= 180:
+    elif diff_days <= 186:
         return 100
     elif diff_days <= 365:
         return 50

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -30,29 +30,47 @@ class TestCalculateTimeScore:
         actual = 1609459200000
         # 3 days off
         guessed = actual + (3 * 24 * 60 * 60 * 1000)
-        assert calculate_time_score(guessed, actual) == 400
+        assert calculate_time_score(guessed, actual) == 450
 
     def test_within_one_month(self):
         actual = 1609459200000
         # 15 days off
         guessed = actual + (15 * 24 * 60 * 60 * 1000)
+        assert calculate_time_score(guessed, actual) == 400
+
+    def test_one_month_off(self):
+        # Guessing one month off (e.g., November instead of December)
+        # should give a reasonable score. Month guesses default to the 15th,
+        # so 30-31 days difference is typical for being one month off.
+        actual = 1609459200000
+        # 31 days off (just over one month)
+        guessed = actual + (31 * 24 * 60 * 60 * 1000)
+        assert calculate_time_score(guessed, actual) == 400
+        # 45 days off (solidly between one and two months)
+        guessed = actual + (45 * 24 * 60 * 60 * 1000)
         assert calculate_time_score(guessed, actual) == 300
 
-    def test_within_three_months(self):
+    def test_two_months_off(self):
         actual = 1609459200000
-        # 60 days off
+        # 60 days off (about two months)
         guessed = actual + (60 * 24 * 60 * 60 * 1000)
+        assert calculate_time_score(guessed, actual) == 300
+
+    def test_three_months_off(self):
+        actual = 1609459200000
+        # 90 days off (about three months)
+        guessed = actual + (90 * 24 * 60 * 60 * 1000)
         assert calculate_time_score(guessed, actual) == 200
 
     def test_within_six_months(self):
         actual = 1609459200000
-        # 120 days off
+        # 120 days off (about four months)
         guessed = actual + (120 * 24 * 60 * 60 * 1000)
         assert calculate_time_score(guessed, actual) == 100
 
     def test_within_one_year(self):
         actual = 1609459200000
-        # 300 days off
+        # 300 days off (about ten months)
         guessed = actual + (300 * 24 * 60 * 60 * 1000)
         assert calculate_time_score(guessed, actual) == 50
 
@@ -66,7 +84,7 @@ class TestCalculateTimeScore:
         actual = 1609459200000
         # 3 days before
         guessed = actual - (3 * 24 * 60 * 60 * 1000)
-        assert calculate_time_score(guessed, actual) == 400
+        assert calculate_time_score(guessed, actual) == 450
 
 
 class TestCalculateTotalScore:


### PR DESCRIPTION
## Summary

- Adjusts time scoring brackets to be more fair for "Month Year" format guesses
- Being off by one month now consistently gives 300-400 points instead of potentially only 200 points
- Adds a new 450-point tier for guesses within a week

## Problem

When guessing "November" instead of "December", the score depended heavily on which day of December the actual message was sent:
- If message was December 15 → November 15 guess = exactly 30 days = 300 points ✓
- If message was December 16+ → November 15 guess = 31+ days = only 200 points ✗

This felt arbitrary and punishing for what is essentially a "one month off" guess.

## Solution

Adjusted scoring brackets to be calibrated around month boundaries:

| Difference | Old Points | New Points |
|------------|------------|------------|
| ≤1 day | 500 | 500 |
| 2-7 days | 400 | 450 |
| 8-30/31 days | 300 | 400 |
| 31-62 days | 200 | 300 |
| 63-93 days | 200 | 200 |
| 94-180/186 days | 100 | 100 |
| 187-365 days | 50 | 50 |
| >365 days | 0 | 0 |

## Test plan

- [x] All existing scoring tests updated and passing
- [x] Added new tests specifically for month-boundary scenarios
- [x] Full test suite passes (112 tests)

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)