### PR TITLE
Make author parameter required for /guess command

### DIFF
--- a/bot/commands/game.py
+++ b/bot/commands/game.py
@@ -103,18 +103,19 @@ class GameCommands(commands.Cog):
     @app_commands.describe(
         channel="The channel you think the message is from",
         time="When you think the message was posted (e.g., 'March 2024', 'Jan 15 2023')",
-        author="The user you think sent the message (optional, +500 points if correct)",
+        author="The user you think sent the message (+500 points if correct)",
     )
     async def guess(
         self,
         interaction: discord.Interaction,
         channel: discord.TextChannel,
         time: str,
-        author: discord.Member | None = None,
+        author: discord.Member,
     ):
         """Submit a guess for the current round."""
-        author_info = f", author=@{author.name}" if author else ""
-        logger.info(f"Guess command invoked by {interaction.user}: channel=#{channel.name}, time='{time}'{author_info}")
+        logger.info(
+            f"Guess command invoked by {interaction.user}: channel=#{channel.name}, time='{time}', author=@{author.name}"
+        )
         await interaction.response.defer(ephemeral=True)
 
         if not interaction.guild or not self.bot.game_service:
@@ -224,11 +225,11 @@ A game where you guess which channel a message came from, when it was posted, an
 **Scoring:**
 - **Channel:** 500 points if correct
 - **Time:** 500 points if within 1 day, scaling down to 0
-- **Author:** 500 points if correct (optional)
+- **Author:** 500 points if correct
 
 **Commands:**
 - `/start` - Start a new round
-- `/guess <channel> <time> [author]` - Submit your guess
+- `/guess <channel> <time> <author>` - Submit your guess
 - `/skip` - Skip the current round (mods only)
 - `/leaderboard` - View the leaderboard
 - `/stats [user]` - View player stats

--- a/bot/services/game_service.py
+++ b/bot/services/game_service.py
@@ -314,7 +314,7 @@ class GameService:
         player: discord.Member,
         guessed_channel: discord.TextChannel,
         guessed_time: str,
-        guessed_author: discord.Member | None = None,
+        guessed_author: discord.Member,
     ) -> tuple[bool, str]:
         """Submit a guess for the active round.
 
@@ -345,8 +345,8 @@ class GameService:
         time_score = calculate_time_score(guessed_timestamp_ms, active_round.target_timestamp_ms)
 
         # Calculate author score
-        guessed_author_id = str(guessed_author.id) if guessed_author else None
-        author_correct = guessed_author_id == active_round.target_author_id if guessed_author_id else False
+        guessed_author_id = str(guessed_author.id)
+        author_correct = guessed_author_id == active_round.target_author_id
 
         # Save guess
         await self.db.add_guess(


### PR DESCRIPTION
## Summary
- Makes the `author` parameter required for the `/guess` command instead of optional
- Updates help text to reflect that author is now a required field
- Simplifies game service code since author is always provided

Fixes #4

## Test plan
- [x] All existing tests pass (110 tests)
- [x] Type checker passes with no errors
- [ ] Manual testing: Try using `/guess` command - Discord should now require the author field to be filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)