### PR TITLE
Add lion emoji for perfect guesses

### DIFF
--- a/utils/formatting.py
+++ b/utils/formatting.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 import discord
 
-from bot.services.scoring_service import calculate_total_score
+from bot.services.scoring_service import calculate_total_score, is_perfect_guess
 from models import Guess, PlayerScore
 
 # URL pattern for detecting links
@@ -245,6 +245,7 @@ def format_round_results(
             player_id = guess.player_id
             channel_correct = guess.channel_correct or False
             time_score = guess.time_score or 0
+            author_correct = guess.author_correct or False
 
             details = []
 
@@ -256,10 +257,12 @@ def format_round_results(
 
             # Format author guess
             if guess.guessed_author_id:
-                author_emoji = "✅" if guess.author_correct else "❌"
+                author_emoji = "✅" if author_correct else "❌"
                 details.append(f"Author: {author_emoji}")
 
-            lines.append(f"{i}. <@{player_id}>: **{total_score}** pts ({', '.join(details)})")
+            # Add lion for perfect guesses (for Laura)
+            perfect_indicator = " 🦁" if is_perfect_guess(channel_correct, time_score, author_correct) else ""
+            lines.append(f"{i}. <@{player_id}>: **{total_score}** pts ({', '.join(details)}){perfect_indicator}")
     else:
         lines.append("*No guesses submitted!*")
 


### PR DESCRIPTION
## Summary
- Adds a lion emoji (🦁) next to a player's score when they achieve a perfect guess
- A perfect guess requires: correct channel, time within 1 day, and correct author (1500 points total)

This addresses the critical feedback in issue #9 that the game "needs more lions".

## Test plan
- [x] All 123 existing tests pass
- [x] Linting passes
- [ ] Play a round and achieve a perfect guess to verify the lion appears
- [ ] Verify non-perfect guesses don't show the lion

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)