### PR TITLE
Fix persistent timers for games started in threads

### DIFF
--- a/utils/formatting.py
+++ b/utils/formatting.py
@@ -201,7 +201,7 @@ def _build_game_message(
 
 
 def format_round_results(
-    target_channel: discord.abc.GuildChannel | None,
+    target_channel: discord.abc.GuildChannel | discord.Thread | None,
     target_timestamp_ms: int,
     target_message_id: str,
     target_author_display_name: str | None,


### PR DESCRIPTION
## Summary
- Games started in Discord threads stored a thread ID as `game_channel_id`, but on restart `guild.get_channel()` doesn't return threads and the `isinstance(channel, discord.TextChannel)` check rejected `Thread` objects
- Use `guild.get_channel_or_thread()` for cache lookups and accept both `TextChannel` and `Thread` in the type check
- Updated type annotations throughout `GameService` to use `MessageableChannel = TextChannel | Thread` for the game channel parameter

## Test plan
- [x] Added tests for thread channel restoration from cache
- [x] Added tests for thread channel restoration via API fetch
- [x] All 128 existing tests pass
- [x] Pyright: 0 errors
- [x] Ruff: all checks passed

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)