### PR TITLE
Make message selection much less repetitive

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ DISCORD_TOKEN=your_bot_token_here
 # MESSAGE_SEARCH_LIMIT=100      # Messages to fetch per API call
 # MAX_SEARCH_RETRIES=5          # Channel/time combinations to try
 # LOOKBACK_DAYS=365             # How far back to search for messages
+# RECENT_MESSAGE_MEMORY=100     # Recent rounds whose messages won't be reused
 
 # Message filtering
 # MIN_MESSAGE_LENGTH=200        # Minimum character length for messages

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ messages from there, and choose uniformly among the interesting ones in the batc
 Targets used in the last `RECENT_MESSAGE_MEMORY` rounds are skipped unless nothing
 else can be found.
 
+This is not uniform over all history — quiet channels are still over-sampled
+relative to busy ones, since channels are chosen uniformly.
+
 ## Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -113,7 +113,16 @@ MESSAGE_SEARCH_LIMIT = 100       # Messages to fetch per API call
 MAX_SEARCH_RETRIES = 5           # How many channel/time combos to try
 LOOKBACK_DAYS = 365              # How far back to look for messages
 MIN_MESSAGE_LENGTH = 200         # Minimum characters for "interesting"
+RECENT_MESSAGE_MEMORY = 100      # Recent rounds whose messages won't be reused
 ```
+
+### How messages are picked
+
+The bot can't enumerate a channel's history, so it samples: pick a random channel,
+jump to a random point in time within that channel's lifespan, fetch a batch of
+messages from there, and choose uniformly among the interesting ones in the batch.
+Targets used in the last `RECENT_MESSAGE_MEMORY` rounds are skipped unless nothing
+else can be found.
 
 ## Project Structure
 

--- a/bot/services/game_service.py
+++ b/bot/services/game_service.py
@@ -172,9 +172,10 @@ class GameService:
             logger.info(f"Round already active in channel #{channel.name}")
             return (False, "A round is already active! Wait for it to finish.")
 
-        # Select random message from guild history
+        # Select random message from guild history, avoiding recently used targets
         logger.info("Searching for a random message from guild history...")
-        result = await self.message_selector.select_random_message(guild)
+        recent_target_ids = await self.db.get_recent_target_message_ids(guild_id, Config.RECENT_MESSAGE_MEMORY)
+        result = await self.message_selector.select_random_message(guild, exclude_message_ids=recent_target_ids)
         if not result:
             return (
                 False,

--- a/bot/services/message_selector.py
+++ b/bot/services/message_selector.py
@@ -4,7 +4,7 @@ import logging
 import random
 import re
 import time
-from collections.abc import Container
+from collections.abc import Set as AbstractSet
 
 import discord
 
@@ -16,7 +16,8 @@ logger = logging.getLogger(__name__)
 # URL pattern for detecting links
 URL_PATTERN = re.compile(r"https?://\S+")
 
-# A batch with fewer messages than this is too sparse to sample from fairly
+# Batches smaller than this only happen at the very end of a channel's eligible
+# history, where the candidate pool is tiny and would repeat constantly
 MIN_BATCH_SIZE = 5
 
 
@@ -55,7 +56,7 @@ class MessageSelector:
     async def select_random_message(
         self,
         guild: discord.Guild,
-        exclude_message_ids: Container[str] | None = None,
+        exclude_message_ids: AbstractSet[str] | None = None,
     ) -> tuple[discord.Message, discord.TextChannel] | None:
         """Select a random interesting message from the guild's history.
 
@@ -67,38 +68,34 @@ class MessageSelector:
         Returns a tuple of (message, channel) if found, or None if no
         suitable message could be found after all retries.
         """
-        # Get list of text channels the bot can read
-        readable_channels = self._get_readable_channels(guild)
-
-        if not readable_channels:
-            logger.warning(f"No readable text channels in guild {guild.id}")
-            return None
-
-        excluded = exclude_message_ids if exclude_message_ids is not None else ()
+        excluded = exclude_message_ids if exclude_message_ids is not None else frozenset()
 
         # Calculate time bounds
         now_ms = int(time.time() * 1000)
         min_age_ms = Config.MIN_MESSAGE_AGE_HOURS * 60 * 60 * 1000
         max_timestamp_ms = now_ms - min_age_ms
         min_timestamp_ms = now_ms - (Config.LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
+        before_snowflake = timestamp_ms_to_snowflake(max_timestamp_ms)
+
+        # Pair each readable channel with its own search window up front. Channels
+        # with no history in the window are dropped here rather than wasting one of
+        # our retries, since working this out costs no API calls.
+        searchable = self._get_searchable_channels(guild, min_timestamp_ms, max_timestamp_ms)
+
+        if not searchable:
+            logger.warning(f"No readable channels with history in the search window in guild {guild.id}")
+            return None
 
         # Best candidate that was excluded as recently used, in case we find nothing else
         fallback: tuple[discord.Message, discord.TextChannel] | None = None
 
         for attempt in range(Config.MAX_SEARCH_RETRIES):
-            # Pick a random channel
-            channel = random.choice(readable_channels)
-
-            # Narrow the search window to when this channel was actually active, so
+            # Pick a random channel and a random point within its own lifespan, so
             # that timestamps before the channel existed don't all collapse onto its
             # oldest messages
-            bounds = self._channel_search_bounds(channel, min_timestamp_ms, max_timestamp_ms)
-            if bounds is None:
-                logger.info(f"Channel #{channel.name} has no history in the search window, retrying...")
-                continue
-            channel_min_ms, channel_max_ms = bounds
+            entry = random.choice(searchable)
+            channel, (channel_min_ms, channel_max_ms) = entry
 
-            # Generate random timestamp in range
             random_timestamp_ms = random.randint(channel_min_ms, channel_max_ms)
             after_snowflake = timestamp_ms_to_snowflake(random_timestamp_ms)
 
@@ -107,26 +104,29 @@ class MessageSelector:
             )
 
             try:
-                # Fetch messages starting from the random point
+                # Fetch messages starting from the random point. `before` keeps the
+                # tail of the batch from crossing the minimum-age cutoff.
                 messages = []
                 async for msg in channel.history(
                     after=discord.Object(id=after_snowflake),
+                    before=discord.Object(id=before_snowflake),
                     limit=Config.MESSAGE_SEARCH_LIMIT,
                     oldest_first=True,
                 ):
                     messages.append(msg)
 
-                # If we got very few messages, this channel/time is too sparse
+                # A short batch means the timestamp landed within the last few
+                # eligible messages of the channel (it does not say anything about
+                # how busy the channel was around that time). Those batches are a
+                # tiny, heavily repeated candidate pool, so skip them.
                 if len(messages) < MIN_BATCH_SIZE:
-                    logger.info(
-                        f"Channel #{channel.name} too sparse at this time ({len(messages)} messages found), retrying..."
-                    )
+                    logger.info(f"Only {len(messages)} messages left after this point in #{channel.name}, retrying...")
                     continue
 
                 # Pick uniformly from every interesting message in the batch. Taking
-                # the *first* one instead would weight each message by how long the
-                # channel was quiet before it, which heavily favors the same handful
-                # of post-lull messages.
+                # the *first* one instead would weight each message by the gap since
+                # the previous interesting message, which heavily favors the same
+                # handful of post-lull messages.
                 interesting = [msg for msg in messages if is_interesting_message(msg)]
                 candidates = [msg for msg in interesting if str(msg.id) not in excluded]
 
@@ -138,8 +138,9 @@ class MessageSelector:
                     )
                     return (chosen, channel)
 
-                if interesting and fallback is None:
-                    fallback = (random.choice(interesting), channel)
+                if interesting:
+                    if fallback is None:
+                        fallback = (random.choice(interesting), channel)
                     logger.info(f"All {len(interesting)} candidates in #{channel.name} used recently, retrying...")
                 else:
                     logger.info(
@@ -148,10 +149,10 @@ class MessageSelector:
 
             except discord.Forbidden:
                 logger.warning(f"Lost permission to read channel #{channel.name}")
-                readable_channels.remove(channel)
-                if not readable_channels:
+                searchable.remove(entry)
+                if not searchable:
                     logger.warning("No more readable channels left")
-                    return None
+                    break
             except discord.HTTPException as e:
                 logger.warning(f"HTTP error fetching history: {e}")
                 continue
@@ -162,6 +163,22 @@ class MessageSelector:
 
         logger.warning(f"Failed to find interesting message after {Config.MAX_SEARCH_RETRIES} attempts")
         return None
+
+    def _get_searchable_channels(
+        self, guild: discord.Guild, min_timestamp_ms: int, max_timestamp_ms: int
+    ) -> list[tuple[discord.TextChannel, tuple[int, int]]]:
+        """Pair every readable channel with the time window worth searching in it.
+
+        Channels whose history doesn't overlap the search window are omitted.
+        """
+        searchable = []
+        for channel in self._get_readable_channels(guild):
+            bounds = self._channel_search_bounds(channel, min_timestamp_ms, max_timestamp_ms)
+            if bounds is None:
+                logger.debug(f"Skipping #{channel.name}: no history in the search window")
+                continue
+            searchable.append((channel, bounds))
+        return searchable
 
     def _channel_search_bounds(
         self, channel: discord.TextChannel, min_timestamp_ms: int, max_timestamp_ms: int

--- a/bot/services/message_selector.py
+++ b/bot/services/message_selector.py
@@ -86,7 +86,8 @@ class MessageSelector:
             logger.warning(f"No readable channels with history in the search window in guild {guild.id}")
             return None
 
-        # Best candidate that was excluded as recently used, in case we find nothing else
+        # First message we had to reject as recently used, kept in case every
+        # attempt comes up empty
         fallback: tuple[discord.Message, discord.TextChannel] | None = None
 
         for attempt in range(Config.MAX_SEARCH_RETRIES):
@@ -189,12 +190,14 @@ class MessageSelector:
         this costs no API calls. Returns None if the channel has no history that
         overlaps the search window.
         """
+        # Discord never rewinds last_message_id, even when that message is
+        # deleted, so None means nothing has ever been posted here
+        if channel.last_message_id is None:
+            return None
+
         created_ms = int(channel.created_at.timestamp() * 1000)
         start_ms = max(min_timestamp_ms, created_ms)
-
-        end_ms = max_timestamp_ms
-        if channel.last_message_id is not None:
-            end_ms = min(end_ms, snowflake_to_timestamp_ms(channel.last_message_id))
+        end_ms = min(max_timestamp_ms, snowflake_to_timestamp_ms(channel.last_message_id))
 
         if start_ms > end_ms:
             return None

--- a/bot/services/message_selector.py
+++ b/bot/services/message_selector.py
@@ -20,6 +20,8 @@ URL_PATTERN = re.compile(r"https?://\S+")
 # history, where the candidate pool is tiny and would repeat constantly
 MIN_BATCH_SIZE = 5
 
+DAY_MS = 24 * 60 * 60 * 1000
+
 
 def is_interesting_message(message: discord.Message) -> bool:
     """Check if a message is interesting enough for the game.
@@ -74,7 +76,7 @@ class MessageSelector:
         now_ms = int(time.time() * 1000)
         min_age_ms = Config.MIN_MESSAGE_AGE_HOURS * 60 * 60 * 1000
         max_timestamp_ms = now_ms - min_age_ms
-        min_timestamp_ms = now_ms - (Config.LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
+        min_timestamp_ms = now_ms - (Config.LOOKBACK_DAYS * DAY_MS)
         before_snowflake = timestamp_ms_to_snowflake(max_timestamp_ms)
 
         # Pair each readable channel with its own search window up front. Channels
@@ -172,13 +174,21 @@ class MessageSelector:
 
         Channels whose history doesn't overlap the search window are omitted.
         """
+        readable = self._get_readable_channels(guild)
         searchable = []
-        for channel in self._get_readable_channels(guild):
+        skipped = []
+        for channel in readable:
             bounds = self._channel_search_bounds(channel, min_timestamp_ms, max_timestamp_ms)
             if bounds is None:
-                logger.debug(f"Skipping #{channel.name}: no history in the search window")
+                skipped.append(channel.name)
                 continue
             searchable.append((channel, bounds))
+
+        if skipped:
+            logger.info(
+                f"Searching {len(searchable)} of {len(readable)} readable channels; "
+                f"skipped {len(skipped)} with no eligible history: {', '.join('#' + name for name in skipped)}"
+            )
         return searchable
 
     def _channel_search_bounds(
@@ -193,13 +203,22 @@ class MessageSelector:
         # Discord never rewinds last_message_id, even when that message is
         # deleted, so None means nothing has ever been posted here
         if channel.last_message_id is None:
+            logger.debug(f"#{channel.name} has never had a message")
             return None
 
         created_ms = int(channel.created_at.timestamp() * 1000)
+        last_message_ms = snowflake_to_timestamp_ms(channel.last_message_id)
         start_ms = max(min_timestamp_ms, created_ms)
-        end_ms = min(max_timestamp_ms, snowflake_to_timestamp_ms(channel.last_message_id))
+        end_ms = min(max_timestamp_ms, last_message_ms)
 
         if start_ms > end_ms:
+            if last_message_ms < min_timestamp_ms:
+                reason = (
+                    f"last message was {(min_timestamp_ms - last_message_ms) // DAY_MS} days before the lookback window"
+                )
+            else:
+                reason = f"created {(created_ms - max_timestamp_ms) // (60 * 60 * 1000)}h after the minimum message age cutoff"
+            logger.debug(f"#{channel.name} has no eligible history: {reason}")
             return None
         return (start_ms, end_ms)
 

--- a/bot/services/message_selector.py
+++ b/bot/services/message_selector.py
@@ -4,16 +4,20 @@ import logging
 import random
 import re
 import time
+from collections.abc import Container
 
 import discord
 
 from config import Config
-from utils.snowflake import timestamp_ms_to_snowflake
+from utils.snowflake import snowflake_to_timestamp_ms, timestamp_ms_to_snowflake
 
 logger = logging.getLogger(__name__)
 
 # URL pattern for detecting links
 URL_PATTERN = re.compile(r"https?://\S+")
+
+# A batch with fewer messages than this is too sparse to sample from fairly
+MIN_BATCH_SIZE = 5
 
 
 def is_interesting_message(message: discord.Message) -> bool:
@@ -48,8 +52,17 @@ def is_interesting_message(message: discord.Message) -> bool:
 class MessageSelector:
     """Service for selecting random messages from guild history."""
 
-    async def select_random_message(self, guild: discord.Guild) -> tuple[discord.Message, discord.TextChannel] | None:
+    async def select_random_message(
+        self,
+        guild: discord.Guild,
+        exclude_message_ids: Container[str] | None = None,
+    ) -> tuple[discord.Message, discord.TextChannel] | None:
         """Select a random interesting message from the guild's history.
+
+        Args:
+            guild: The guild to search.
+            exclude_message_ids: Message IDs to avoid (e.g. recently used targets).
+                These are only used as a last resort if nothing else is found.
 
         Returns a tuple of (message, channel) if found, or None if no
         suitable message could be found after all retries.
@@ -61,18 +74,32 @@ class MessageSelector:
             logger.warning(f"No readable text channels in guild {guild.id}")
             return None
 
+        excluded = exclude_message_ids if exclude_message_ids is not None else ()
+
         # Calculate time bounds
         now_ms = int(time.time() * 1000)
         min_age_ms = Config.MIN_MESSAGE_AGE_HOURS * 60 * 60 * 1000
         max_timestamp_ms = now_ms - min_age_ms
         min_timestamp_ms = now_ms - (Config.LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
 
+        # Best candidate that was excluded as recently used, in case we find nothing else
+        fallback: tuple[discord.Message, discord.TextChannel] | None = None
+
         for attempt in range(Config.MAX_SEARCH_RETRIES):
             # Pick a random channel
             channel = random.choice(readable_channels)
 
+            # Narrow the search window to when this channel was actually active, so
+            # that timestamps before the channel existed don't all collapse onto its
+            # oldest messages
+            bounds = self._channel_search_bounds(channel, min_timestamp_ms, max_timestamp_ms)
+            if bounds is None:
+                logger.info(f"Channel #{channel.name} has no history in the search window, retrying...")
+                continue
+            channel_min_ms, channel_max_ms = bounds
+
             # Generate random timestamp in range
-            random_timestamp_ms = random.randint(min_timestamp_ms, max_timestamp_ms)
+            random_timestamp_ms = random.randint(channel_min_ms, channel_max_ms)
             after_snowflake = timestamp_ms_to_snowflake(random_timestamp_ms)
 
             logger.info(
@@ -90,19 +117,34 @@ class MessageSelector:
                     messages.append(msg)
 
                 # If we got very few messages, this channel/time is too sparse
-                if len(messages) < 5:
+                if len(messages) < MIN_BATCH_SIZE:
                     logger.info(
                         f"Channel #{channel.name} too sparse at this time ({len(messages)} messages found), retrying..."
                     )
                     continue
 
-                # Find the first interesting message
-                for msg in messages:
-                    if is_interesting_message(msg):
-                        logger.info(f"Selected message {msg.id} from #{channel.name} on attempt {attempt + 1}")
-                        return (msg, channel)
+                # Pick uniformly from every interesting message in the batch. Taking
+                # the *first* one instead would weight each message by how long the
+                # channel was quiet before it, which heavily favors the same handful
+                # of post-lull messages.
+                interesting = [msg for msg in messages if is_interesting_message(msg)]
+                candidates = [msg for msg in interesting if str(msg.id) not in excluded]
 
-                logger.info(f"No interesting messages in batch of {len(messages)} from #{channel.name}, retrying...")
+                if candidates:
+                    chosen = random.choice(candidates)
+                    logger.info(
+                        f"Selected message {chosen.id} from #{channel.name} "
+                        f"({len(candidates)} candidates) on attempt {attempt + 1}"
+                    )
+                    return (chosen, channel)
+
+                if interesting and fallback is None:
+                    fallback = (random.choice(interesting), channel)
+                    logger.info(f"All {len(interesting)} candidates in #{channel.name} used recently, retrying...")
+                else:
+                    logger.info(
+                        f"No interesting messages in batch of {len(messages)} from #{channel.name}, retrying..."
+                    )
 
             except discord.Forbidden:
                 logger.warning(f"Lost permission to read channel #{channel.name}")
@@ -114,8 +156,32 @@ class MessageSelector:
                 logger.warning(f"HTTP error fetching history: {e}")
                 continue
 
+        if fallback is not None:
+            logger.info(f"Falling back to recently used message {fallback[0].id} from #{fallback[1].name}")
+            return fallback
+
         logger.warning(f"Failed to find interesting message after {Config.MAX_SEARCH_RETRIES} attempts")
         return None
+
+    def _channel_search_bounds(
+        self, channel: discord.TextChannel, min_timestamp_ms: int, max_timestamp_ms: int
+    ) -> tuple[int, int] | None:
+        """Clamp the global search window to a channel's own lifespan.
+
+        Both bounds come from snowflakes already cached on the channel object, so
+        this costs no API calls. Returns None if the channel has no history that
+        overlaps the search window.
+        """
+        created_ms = int(channel.created_at.timestamp() * 1000)
+        start_ms = max(min_timestamp_ms, created_ms)
+
+        end_ms = max_timestamp_ms
+        if channel.last_message_id is not None:
+            end_ms = min(end_ms, snowflake_to_timestamp_ms(channel.last_message_id))
+
+        if start_ms > end_ms:
+            return None
+        return (start_ms, end_ms)
 
     def _get_readable_channels(self, guild: discord.Guild) -> list[discord.TextChannel]:
         """Get list of text channels the bot can read."""

--- a/config.py
+++ b/config.py
@@ -31,6 +31,8 @@ class Settings(BaseSettings):
     message_search_limit: int = Field(default=100, alias="MESSAGE_SEARCH_LIMIT")
     max_search_retries: int = Field(default=5, alias="MAX_SEARCH_RETRIES")
     lookback_days: int = Field(default=365, alias="LOOKBACK_DAYS")
+    # How many recent rounds' target messages to avoid reusing
+    recent_message_memory: int = Field(default=100, alias="RECENT_MESSAGE_MEMORY")
 
     # Message filtering
     min_message_length: int = Field(default=200, alias="MIN_MESSAGE_LENGTH")
@@ -53,4 +55,5 @@ class Config:
     MESSAGE_SEARCH_LIMIT = settings.message_search_limit
     MAX_SEARCH_RETRIES = settings.max_search_retries
     LOOKBACK_DAYS = settings.lookback_days
+    RECENT_MESSAGE_MEMORY = settings.recent_message_memory
     MIN_MESSAGE_LENGTH = settings.min_message_length

--- a/db/database.py
+++ b/db/database.py
@@ -127,6 +127,24 @@ class Database:
         )
         return GameRound(**dict(row)) if row else None
 
+    async def get_recent_target_message_ids(self, guild_id: str, limit: int) -> set[str]:
+        """Get the target message IDs of the most recent rounds in a guild.
+
+        Used to avoid showing players the same message again too soon.
+        """
+        if limit <= 0:
+            return set()
+        rows = await self.fetch_all(
+            """
+            SELECT target_message_id FROM game_rounds
+            WHERE guild_id = ?
+            ORDER BY id DESC
+            LIMIT ?
+            """,
+            (guild_id, limit),
+        )
+        return {row["target_message_id"] for row in rows}
+
     async def end_round(self, round_id: int, status: str = "completed") -> None:
         """End a game round and clear the timer."""
         await self.execute(

--- a/db/migrations/004_add_rounds_recency_index.sql
+++ b/db/migrations/004_add_rounds_recency_index.sql
@@ -1,0 +1,6 @@
+-- Covering index for looking up recently used target messages in a guild.
+-- Without it, get_recent_target_message_ids has to materialize and sort every
+-- round in the guild on each round start (idx_rounds_guild_status orders by
+-- status, not id, so it can't stream in id DESC order).
+CREATE INDEX IF NOT EXISTS idx_rounds_guild_recent
+    ON game_rounds(guild_id, id DESC, target_message_id);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,12 +27,13 @@ def mock_discord_message():
             attachments=None,
             embeds=None,
             author_id=12345,
+            message_id=123456789,
         ):
             self.content = content
             self.author = MockAuthor(bot=author_bot, user_id=author_id)
             self.attachments = attachments or []
             self.embeds = embeds or []
-            self.id = 123456789
+            self.id = message_id
             self.guild = None  # For escape_mentions; None means mentions won't be resolved
 
     return MockMessage

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -114,6 +114,49 @@ class TestGameRounds:
         assert await db.get_round_number(guild_id) == 2
 
 
+class TestRecentTargetMessageIds:
+    async def _create_round(self, db, guild_id: str, message_id: str) -> None:
+        await db.create_round(
+            guild_id=guild_id,
+            game_channel_id="456",
+            target_message_id=message_id,
+            target_channel_id="101",
+            target_timestamp_ms=1609459200000,
+            target_author_id="author123",
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_without_rounds(self, db):
+        assert await db.get_recent_target_message_ids("123", 10) == set()
+
+    @pytest.mark.asyncio
+    async def test_returns_target_ids(self, db):
+        for message_id in ("1", "2", "3"):
+            await self._create_round(db, "123", message_id)
+
+        assert await db.get_recent_target_message_ids("123", 10) == {"1", "2", "3"}
+
+    @pytest.mark.asyncio
+    async def test_limits_to_most_recent(self, db):
+        for message_id in ("1", "2", "3"):
+            await self._create_round(db, "123", message_id)
+
+        assert await db.get_recent_target_message_ids("123", 2) == {"2", "3"}
+
+    @pytest.mark.asyncio
+    async def test_scoped_to_guild(self, db):
+        await self._create_round(db, "123", "1")
+        await self._create_round(db, "456", "2")
+
+        assert await db.get_recent_target_message_ids("123", 10) == {"1"}
+
+    @pytest.mark.asyncio
+    async def test_zero_limit(self, db):
+        await self._create_round(db, "123", "1")
+
+        assert await db.get_recent_target_message_ids("123", 0) == set()
+
+
 class TestGuesses:
     @pytest.mark.asyncio
     async def test_add_guess(self, db):

--- a/tests/test_message_selector.py
+++ b/tests/test_message_selector.py
@@ -3,12 +3,14 @@
 import time
 from datetime import datetime, timedelta, timezone
 from typing import cast
+from unittest.mock import MagicMock
 
 import discord
 import pytest
 
 from bot.services.message_selector import URL_PATTERN, MessageSelector, is_interesting_message
-from utils.snowflake import timestamp_ms_to_snowflake
+from config import Config
+from utils.snowflake import snowflake_to_timestamp_ms, timestamp_ms_to_snowflake
 
 DAY_MS = 24 * 60 * 60 * 1000
 
@@ -82,21 +84,34 @@ class TestIsInterestingMessage:
 class MockChannel:
     """A text channel whose history() returns a fixed list of messages."""
 
-    def __init__(self, name="general", messages=None, created_ms=None, last_message_ms=None):
+    def __init__(
+        self,
+        name="general",
+        messages=None,
+        created_ms=None,
+        last_message_ms=None,
+        forbidden_after=None,
+    ):
         self.name = name
         self.id = 999
         self._messages = messages or []
+        self._forbidden_after = forbidden_after
         now_ms = int(time.time() * 1000)
         created_ms = created_ms if created_ms is not None else now_ms - 400 * DAY_MS
         self.created_at = datetime.fromtimestamp(created_ms / 1000, tz=timezone.utc)
         self.last_message_id = timestamp_ms_to_snowflake(last_message_ms) if last_message_ms is not None else None
         self.history_calls = []
+        self.before_calls = []
 
-    def history(self, *, after, limit, oldest_first):
+    def history(self, *, after, before, limit, oldest_first):
         self.history_calls.append(after.id)
+        self.before_calls.append(before.id)
         messages = self._messages
+        forbid = self._forbidden_after is not None and len(self.history_calls) > self._forbidden_after
 
         async def _iter():
+            if forbid:
+                raise discord.Forbidden(MagicMock(status=403), "Missing Access")
             for msg in messages[:limit]:
                 yield msg
 
@@ -167,6 +182,16 @@ class TestChannelSearchBounds:
         assert bounds is not None
         assert bounds[1] == last_message_ms
 
+    def test_returns_none_for_channel_dead_before_the_window(self):
+        now_ms = int(time.time() * 1000)
+        # Last posted well before the lookback window opens
+        channel = MockChannel(created_ms=now_ms - 800 * DAY_MS, last_message_ms=now_ms - 500 * DAY_MS)
+
+        assert (
+            MessageSelector()._channel_search_bounds(as_channel(channel), now_ms - 365 * DAY_MS, now_ms - DAY_MS)
+            is None
+        )
+
     def test_returns_none_when_channel_is_newer_than_window(self):
         now_ms = int(time.time() * 1000)
         # Created an hour ago, but messages must be at least a day old
@@ -214,6 +239,30 @@ class TestSelectRandomMessage:
         )
         assert channel.history_calls
         assert all(window[0] <= call <= window[1] for call in channel.history_calls)
+
+    @pytest.mark.asyncio
+    async def test_history_is_bounded_by_minimum_message_age(self, mock_discord_message):
+        messages = make_messages(mock_discord_message, 10, interesting_ids={3})
+        channel = MockChannel(messages=messages)
+
+        await MessageSelector().select_random_message(as_guild(channel))
+
+        # The batch must not be allowed to run past the minimum-age cutoff
+        cutoff_ms = int(time.time() * 1000) - Config.MIN_MESSAGE_AGE_HOURS * 60 * 60 * 1000
+        assert channel.before_calls
+        assert all(abs(snowflake_to_timestamp_ms(before) - cutoff_ms) < 1000 for before in channel.before_calls)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_channel_becomes_unreadable(self, mock_discord_message):
+        # Only interesting message was used recently, then the bot loses access to
+        # the guild's only channel. The already-fetched fallback should still be used.
+        messages = make_messages(mock_discord_message, 10, interesting_ids={4})
+        channel = MockChannel(messages=messages, forbidden_after=1)
+
+        result = await MessageSelector().select_random_message(as_guild(channel), exclude_message_ids={"4"})
+
+        assert result is not None
+        assert result[0].id == 4
 
     @pytest.mark.asyncio
     async def test_skips_recently_used_messages(self, mock_discord_message):

--- a/tests/test_message_selector.py
+++ b/tests/test_message_selector.py
@@ -1,6 +1,16 @@
 """Tests for message selector."""
 
-from bot.services.message_selector import URL_PATTERN, is_interesting_message
+import time
+from datetime import datetime, timedelta, timezone
+from typing import cast
+
+import discord
+import pytest
+
+from bot.services.message_selector import URL_PATTERN, MessageSelector, is_interesting_message
+from utils.snowflake import timestamp_ms_to_snowflake
+
+DAY_MS = 24 * 60 * 60 * 1000
 
 
 class TestUrlPattern:
@@ -67,3 +77,188 @@ class TestIsInterestingMessage:
         # Exactly 200 characters - enough
         msg = mock_discord_message(content="A" * 200)
         assert is_interesting_message(msg) is True
+
+
+class MockChannel:
+    """A text channel whose history() returns a fixed list of messages."""
+
+    def __init__(self, name="general", messages=None, created_ms=None, last_message_ms=None):
+        self.name = name
+        self.id = 999
+        self._messages = messages or []
+        now_ms = int(time.time() * 1000)
+        created_ms = created_ms if created_ms is not None else now_ms - 400 * DAY_MS
+        self.created_at = datetime.fromtimestamp(created_ms / 1000, tz=timezone.utc)
+        self.last_message_id = timestamp_ms_to_snowflake(last_message_ms) if last_message_ms is not None else None
+        self.history_calls = []
+
+    def history(self, *, after, limit, oldest_first):
+        self.history_calls.append(after.id)
+        messages = self._messages
+
+        async def _iter():
+            for msg in messages[:limit]:
+                yield msg
+
+        return _iter()
+
+    def permissions_for(self, _member):
+        class Permissions:
+            read_messages = True
+            read_message_history = True
+
+        return Permissions()
+
+
+class MockChannelGuild:
+    def __init__(self, channels):
+        self.id = 1
+        self.me = object()
+        self.text_channels = channels
+
+
+def as_guild(*channels: MockChannel) -> discord.Guild:
+    """Wrap mock channels in a guild the selector will accept."""
+    return cast(discord.Guild, MockChannelGuild(list(channels)))
+
+
+def as_channel(channel: MockChannel) -> discord.TextChannel:
+    return cast(discord.TextChannel, channel)
+
+
+def make_messages(mock_discord_message, count, interesting_ids=()):
+    """Build a batch where only `interesting_ids` pass is_interesting_message."""
+    return [
+        mock_discord_message(
+            content=("A" * 200) if i in interesting_ids else "short",
+            message_id=i,
+        )
+        for i in range(count)
+    ]
+
+
+class TestChannelSearchBounds:
+    def test_clamps_start_to_channel_creation(self):
+        now_ms = int(time.time() * 1000)
+        channel = MockChannel(created_ms=now_ms - 30 * DAY_MS)
+
+        bounds = MessageSelector()._channel_search_bounds(as_channel(channel), now_ms - 365 * DAY_MS, now_ms - DAY_MS)
+
+        assert bounds is not None
+        assert bounds[0] == pytest.approx(now_ms - 30 * DAY_MS, abs=1000)
+
+    def test_keeps_window_start_for_older_channels(self):
+        now_ms = int(time.time() * 1000)
+        channel = MockChannel(created_ms=now_ms - 800 * DAY_MS)
+        window_start = now_ms - 365 * DAY_MS
+
+        bounds = MessageSelector()._channel_search_bounds(as_channel(channel), window_start, now_ms - DAY_MS)
+
+        assert bounds is not None
+        assert bounds[0] == window_start
+
+    def test_clamps_end_to_last_message(self):
+        now_ms = int(time.time() * 1000)
+        last_message_ms = now_ms - 100 * DAY_MS
+        channel = MockChannel(last_message_ms=last_message_ms)
+
+        bounds = MessageSelector()._channel_search_bounds(as_channel(channel), now_ms - 365 * DAY_MS, now_ms - DAY_MS)
+
+        assert bounds is not None
+        assert bounds[1] == last_message_ms
+
+    def test_returns_none_when_channel_is_newer_than_window(self):
+        now_ms = int(time.time() * 1000)
+        # Created an hour ago, but messages must be at least a day old
+        channel = MockChannel(created_ms=now_ms - 60 * 60 * 1000)
+
+        assert (
+            MessageSelector()._channel_search_bounds(as_channel(channel), now_ms - 365 * DAY_MS, now_ms - DAY_MS)
+            is None
+        )
+
+
+class TestSelectRandomMessage:
+    @pytest.mark.asyncio
+    async def test_samples_across_all_interesting_messages(self, mock_discord_message):
+        # Three interesting messages in the batch; the old "take the first" logic
+        # would always return message 1
+        messages = make_messages(mock_discord_message, 10, interesting_ids={1, 5, 9})
+        guild = as_guild(MockChannel(messages=messages))
+        selector = MessageSelector()
+
+        seen = set()
+        for _ in range(200):
+            result = await selector.select_random_message(guild)
+            assert result is not None
+            seen.add(result[0].id)
+
+        assert seen == {1, 5, 9}
+
+    @pytest.mark.asyncio
+    async def test_search_starts_within_channel_lifespan(self, mock_discord_message):
+        now_ms = int(time.time() * 1000)
+        created_ms = now_ms - 30 * DAY_MS
+        messages = make_messages(mock_discord_message, 10, interesting_ids={3})
+        channel = MockChannel(messages=messages, created_ms=created_ms, last_message_ms=now_ms - 2 * DAY_MS)
+        selector = MessageSelector()
+
+        for _ in range(50):
+            await selector.select_random_message(as_guild(channel))
+
+        # Every probe should land inside [created, last message], never in the
+        # dead time before the channel existed
+        window = (
+            timestamp_ms_to_snowflake(created_ms - 1000),
+            timestamp_ms_to_snowflake(now_ms - 2 * DAY_MS + 1000),
+        )
+        assert channel.history_calls
+        assert all(window[0] <= call <= window[1] for call in channel.history_calls)
+
+    @pytest.mark.asyncio
+    async def test_skips_recently_used_messages(self, mock_discord_message):
+        messages = make_messages(mock_discord_message, 10, interesting_ids={1, 5, 9})
+        guild = as_guild(MockChannel(messages=messages))
+        selector = MessageSelector()
+
+        for _ in range(50):
+            result = await selector.select_random_message(guild, exclude_message_ids={"1", "9"})
+            assert result is not None
+            assert result[0].id == 5
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_used_message_when_nothing_else_available(self, mock_discord_message):
+        messages = make_messages(mock_discord_message, 10, interesting_ids={4})
+        guild = as_guild(MockChannel(messages=messages))
+
+        result = await MessageSelector().select_random_message(guild, exclude_message_ids={"4"})
+
+        assert result is not None
+        assert result[0].id == 4
+
+    @pytest.mark.asyncio
+    async def test_returns_none_without_interesting_messages(self, mock_discord_message):
+        messages = make_messages(mock_discord_message, 10)
+        guild = as_guild(MockChannel(messages=messages))
+
+        assert await MessageSelector().select_random_message(guild) is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_sparse_channel(self, mock_discord_message):
+        messages = make_messages(mock_discord_message, 3, interesting_ids={0, 1, 2})
+        guild = as_guild(MockChannel(messages=messages))
+
+        assert await MessageSelector().select_random_message(guild) is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_without_readable_channels(self):
+        assert await MessageSelector().select_random_message(as_guild()) is None
+
+    @pytest.mark.asyncio
+    async def test_skips_channels_with_no_history_in_window(self, mock_discord_message):
+        too_new = MockChannel(name="new", messages=make_messages(mock_discord_message, 10, interesting_ids={0}))
+        too_new.created_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        guild = as_guild(too_new)
+
+        assert await MessageSelector().select_random_message(guild) is None
+        assert too_new.history_calls == []

--- a/tests/test_message_selector.py
+++ b/tests/test_message_selector.py
@@ -1,5 +1,6 @@
 """Tests for message selector."""
 
+import logging
 import time
 from datetime import datetime, timedelta, timezone
 from typing import cast
@@ -279,6 +280,17 @@ class TestSelectRandomMessage:
             assert result[0].id == 7
 
         assert all(not channel.history_calls for channel in empty)
+
+    @pytest.mark.asyncio
+    async def test_logs_which_channels_were_skipped(self, mock_discord_message, caplog):
+        empty = MockChannel(name="rules", empty=True)
+        real = MockChannel(name="general", messages=make_messages(mock_discord_message, 10, interesting_ids={7}))
+
+        with caplog.at_level(logging.INFO, logger="bot.services.message_selector"):
+            await MessageSelector().select_random_message(as_guild(empty, real))
+
+        assert "Searching 1 of 2 readable channels" in caplog.text
+        assert "#rules" in caplog.text
 
     @pytest.mark.asyncio
     async def test_prefers_fresh_candidate_over_fallback_from_another_channel(self, mock_discord_message, monkeypatch):

--- a/tests/test_message_selector.py
+++ b/tests/test_message_selector.py
@@ -91,6 +91,7 @@ class MockChannel:
         created_ms=None,
         last_message_ms=None,
         forbidden_after=None,
+        empty=False,
     ):
         self.name = name
         self.id = 999
@@ -99,7 +100,11 @@ class MockChannel:
         now_ms = int(time.time() * 1000)
         created_ms = created_ms if created_ms is not None else now_ms - 400 * DAY_MS
         self.created_at = datetime.fromtimestamp(created_ms / 1000, tz=timezone.utc)
-        self.last_message_id = timestamp_ms_to_snowflake(last_message_ms) if last_message_ms is not None else None
+        # `empty` models a channel nobody has ever posted in, where Discord
+        # reports last_message_id as None
+        if last_message_ms is None:
+            last_message_ms = now_ms - 2 * DAY_MS
+        self.last_message_id = None if empty else timestamp_ms_to_snowflake(last_message_ms)
         self.history_calls = []
         self.before_calls = []
 
@@ -192,10 +197,19 @@ class TestChannelSearchBounds:
             is None
         )
 
+    def test_returns_none_for_channel_with_no_messages(self):
+        now_ms = int(time.time() * 1000)
+        channel = MockChannel(empty=True)
+
+        assert (
+            MessageSelector()._channel_search_bounds(as_channel(channel), now_ms - 365 * DAY_MS, now_ms - DAY_MS)
+            is None
+        )
+
     def test_returns_none_when_channel_is_newer_than_window(self):
         now_ms = int(time.time() * 1000)
         # Created an hour ago, but messages must be at least a day old
-        channel = MockChannel(created_ms=now_ms - 60 * 60 * 1000)
+        channel = MockChannel(created_ms=now_ms - 60 * 60 * 1000, last_message_ms=now_ms - 30 * 60 * 1000)
 
         assert (
             MessageSelector()._channel_search_bounds(as_channel(channel), now_ms - 365 * DAY_MS, now_ms - DAY_MS)
@@ -251,6 +265,32 @@ class TestSelectRandomMessage:
         cutoff_ms = int(time.time() * 1000) - Config.MIN_MESSAGE_AGE_HOURS * 60 * 60 * 1000
         assert channel.before_calls
         assert all(abs(snowflake_to_timestamp_ms(before) - cutoff_ms) < 1000 for before in channel.before_calls)
+
+    @pytest.mark.asyncio
+    async def test_empty_channels_never_consume_retries(self, mock_discord_message):
+        # A guild full of channels nobody has ever posted in, plus one real one.
+        # The empty ones must not be probed at all, or they'd exhaust the retries.
+        empty = [MockChannel(name=f"empty-{i}", empty=True) for i in range(10)]
+        real = MockChannel(name="general", messages=make_messages(mock_discord_message, 10, interesting_ids={7}))
+
+        for _ in range(20):
+            result = await MessageSelector().select_random_message(as_guild(*empty, real))
+            assert result is not None
+            assert result[0].id == 7
+
+        assert all(not channel.history_calls for channel in empty)
+
+    @pytest.mark.asyncio
+    async def test_prefers_fresh_candidate_over_fallback_from_another_channel(self, mock_discord_message, monkeypatch):
+        # Enough retries that both channels are near-certain to be tried
+        monkeypatch.setattr(Config, "MAX_SEARCH_RETRIES", 30)
+        used = MockChannel(name="used", messages=make_messages(mock_discord_message, 10, interesting_ids={2}))
+        fresh = MockChannel(name="fresh", messages=make_messages(mock_discord_message, 10, interesting_ids={6}))
+
+        for _ in range(20):
+            result = await MessageSelector().select_random_message(as_guild(used, fresh), exclude_message_ids={"2"})
+            assert result is not None
+            assert result[0].id == 6
 
     @pytest.mark.asyncio
     async def test_falls_back_when_channel_becomes_unreadable(self, mock_discord_message):

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[options]
+exclude-newer = "2026-08-06T22:43:06.409514189Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
A user reported getting the same messages to guess too often. The randomness *source* is fine — `random` is Mersenne Twister seeded from OS entropy and is uniform for `choice`/`randint`, so switching to `secrets` would change nothing. The bias was in the sampling algorithm.

### 1. Random timestamps could land before the channel existed

`min_timestamp_ms` was `now - 365 days` for every channel, but `channel.history(after=T, oldest_first=True)` with `T` before the channel's first message just returns the channel's *oldest* messages. For a channel created 30 days ago, ~92% of draws collapsed onto the same starting point — and therefore the same first interesting message.

Now each channel's draw is clamped to `[created_at, last_message_id]`. Both come from snowflakes already cached on the channel object, so this costs **zero extra API calls** and doesn't require enumerating anything.

### 2. "First interesting message after T" weighted messages by the silence before them

A message's selection probability was proportional to the gap since the previous interesting message. The first message after a quiet weekend was thousands of times more likely than one posted a minute after another. Real channels are mostly quiet, so a small set of post-lull messages absorbed most of the probability mass.

The selector now collects every interesting message in the batch and picks uniformly. The full 100-message batch was already being fetched and then discarded after the first hit, so this is free too.

### 3. No dedup

Nothing checked whether a message had been used before, even though `game_rounds` already stores `target_message_id`. Targets from the last `RECENT_MESSAGE_MEMORY` rounds (default 100, configurable) are now skipped. If a guild is small enough that every candidate has been used recently, it falls back to a used message rather than failing the round.

### Not included

Channel selection is still uniform, so a dead channel with 3 interesting messages a year gets the same weight as the busiest one. Fixing that needs cached per-channel density estimates — tracked in a follow-up issue.

### Testing

`uv run pytest` (145 pass), `uv run pyright`, `uv run ruff check` all clean. New tests cover the timestamp clamping, uniform sampling across a batch, dedup, and the fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)