### PR TITLE
Weight channel selection by activity instead of uniformly

### DIFF
--- a/bot/services/message_selector.py
+++ b/bot/services/message_selector.py
@@ -5,6 +5,7 @@ import random
 import re
 import time
 from collections.abc import Set as AbstractSet
+from dataclasses import dataclass
 
 import discord
 
@@ -21,6 +22,52 @@ URL_PATTERN = re.compile(r"https?://\S+")
 MIN_BATCH_SIZE = 5
 
 DAY_MS = 24 * 60 * 60 * 1000
+
+# How quickly the per-channel density estimate follows new observations. Each
+# probe is noisy (activity varies over a channel's history), so blend rather
+# than replace.
+DENSITY_EWMA_ALPHA = 0.3
+
+# Floor on the density used for channel weighting, equivalent to one message
+# per week. Without it a channel that once measured near-zero would never be
+# probed again and couldn't recover if it came back to life.
+MIN_WEIGHT_DENSITY = 1 / (7 * DAY_MS)
+
+
+@dataclass
+class _ChannelState:
+    """What we've learned about a channel from history probes.
+
+    Kept in memory only: it's all derived from message timestamps we fetch
+    anyway, rebuilds itself within a few rounds after a restart, and storing
+    it would complicate the privacy story for no real gain.
+    """
+
+    # EWMA of messages per millisecond, measured around the points we've probed
+    density_per_ms: float | None = None
+    # Whether we've probed for the first in-window message yet; distinguishes
+    # "never looked" from "looked and found nothing" (first_message_ms=None)
+    probed: bool = False
+    # Timestamp of the channel's first message at or after the search window
+    # start, or None if the probe found no message there
+    first_message_ms: int | None = None
+    # The channel's last_message_id when we probed, to notice new traffic in a
+    # channel whose probe came up empty
+    probed_last_message_id: int | None = None
+
+    def cached_first_message(self, start_ms: int, last_message_id: int | None) -> tuple[bool, int | None]:
+        """Look up the first in-window message for a window starting at start_ms.
+
+        Returns (cache_is_valid, first_message_ms). The lookback window only
+        ever moves forward, so a cached first message stays correct until the
+        window start passes it; a cached "nothing in the window" stays correct
+        until the channel sees a new message.
+        """
+        if not self.probed:
+            return (False, None)
+        if self.first_message_ms is None:
+            return (last_message_id == self.probed_last_message_id, None)
+        return (self.first_message_ms >= start_ms, self.first_message_ms)
 
 
 def is_interesting_message(message: discord.Message) -> bool:
@@ -54,6 +101,10 @@ def is_interesting_message(message: discord.Message) -> bool:
 
 class MessageSelector:
     """Service for selecting random messages from guild history."""
+
+    def __init__(self) -> None:
+        # Channel IDs are globally unique, so one map works across guilds
+        self._channel_states: dict[int, _ChannelState] = {}
 
     async def select_random_message(
         self,
@@ -93,20 +144,39 @@ class MessageSelector:
         fallback: tuple[discord.Message, discord.TextChannel] | None = None
 
         for attempt in range(Config.MAX_SEARCH_RETRIES):
-            # Pick a random channel and a random point within its own lifespan, so
-            # that timestamps before the channel existed don't all collapse onto its
-            # oldest messages
-            entry = random.choice(searchable)
+            # Weight channels by how many eligible messages each is estimated to
+            # hold, so every message in the guild is roughly equally likely
+            # rather than every channel. Recomputed each attempt because every
+            # probe refines the estimates.
+            entry = random.choices(searchable, weights=self._channel_weights(searchable))[0]
             channel, (channel_min_ms, channel_max_ms) = entry
-
-            random_timestamp_ms = random.randint(channel_min_ms, channel_max_ms)
-            after_snowflake = timestamp_ms_to_snowflake(random_timestamp_ms)
 
             logger.info(
                 f"Message search attempt {attempt + 1}/{Config.MAX_SEARCH_RETRIES}: checking #{channel.name}..."
             )
 
             try:
+                # Snap the window start to the first message actually in it, so a
+                # long-dormant channel whose traffic is all recent doesn't collapse
+                # most draws onto its oldest messages
+                first_message_ms = await self._first_in_window_ms(channel, channel_min_ms)
+                if first_message_ms is None or first_message_ms > channel_max_ms:
+                    # last_message_id promised history here, but none of it is in
+                    # the eligible window (deleted, or younger than the minimum age)
+                    logger.info(f"#{channel.name} has no messages in its eligible window, skipping")
+                    searchable.remove(entry)
+                    if not searchable:
+                        logger.warning("No more searchable channels left")
+                        break
+                    continue
+                channel_min_ms = max(channel_min_ms, first_message_ms)
+
+                # Pick a random point within the channel's own message history, so
+                # that timestamps before its first message don't all collapse onto
+                # its oldest messages
+                random_timestamp_ms = random.randint(channel_min_ms, channel_max_ms)
+                after_snowflake = timestamp_ms_to_snowflake(random_timestamp_ms)
+
                 # Fetch messages starting from the random point. `before` keeps the
                 # tail of the batch from crossing the minimum-age cutoff.
                 messages = []
@@ -117,6 +187,10 @@ class MessageSelector:
                     oldest_first=True,
                 ):
                     messages.append(msg)
+
+                # Every batch doubles as a free measurement of how busy the
+                # channel is, which feeds the next round's channel weighting
+                self._observe_density(channel, random_timestamp_ms, channel_max_ms, messages)
 
                 # A short batch means the timestamp landed within the last few
                 # eligible messages of the channel (it does not say anything about
@@ -220,7 +294,95 @@ class MessageSelector:
                 reason = f"created {(created_ms - max_timestamp_ms) // (60 * 60 * 1000)}h after the minimum message age cutoff"
             logger.debug(f"#{channel.name} has no eligible history: {reason}")
             return None
+
+        # Tighten the start further using the cached first-in-window probe, if
+        # we have one; this only reads the cache and never costs an API call
+        state = self._channel_states.get(channel.id)
+        if state is not None:
+            valid, first_message_ms = state.cached_first_message(start_ms, channel.last_message_id)
+            if valid:
+                if first_message_ms is None:
+                    logger.debug(f"#{channel.name} has no messages in the search window")
+                    return None
+                start_ms = max(start_ms, first_message_ms)
+                if start_ms > end_ms:
+                    logger.debug(f"#{channel.name}'s only in-window messages are younger than the age cutoff")
+                    return None
         return (start_ms, end_ms)
+
+    def _channel_weights(self, searchable: list[tuple[discord.TextChannel, tuple[int, int]]]) -> list[float]:
+        """Estimate how many eligible messages each channel holds.
+
+        A channel's weight is its measured message density times the span of
+        its search window. Channels we haven't probed yet get the mean density
+        of the ones we have, so the first round behaves like a uniform pick and
+        the weighting self-calibrates as probes accumulate.
+        """
+        known = [
+            state.density_per_ms
+            for channel, _ in searchable
+            if (state := self._channel_states.get(channel.id)) is not None and state.density_per_ms is not None
+        ]
+        if not known:
+            return [1.0] * len(searchable)
+
+        default_density = sum(known) / len(known)
+        weights = []
+        for channel, (start_ms, end_ms) in searchable:
+            state = self._channel_states.get(channel.id)
+            density = (
+                state.density_per_ms if state is not None and state.density_per_ms is not None else default_density
+            )
+            weights.append(max(density, MIN_WEIGHT_DENSITY) * (end_ms - start_ms + 1))
+        return weights
+
+    def _observe_density(
+        self, channel: discord.TextChannel, probe_ms: int, window_end_ms: int, messages: list[discord.Message]
+    ) -> None:
+        """Fold one history batch into the channel's message-density estimate.
+
+        A full batch of N messages after probe_ms means N messages fell between
+        the probe point and the last message's timestamp. A short batch means
+        the channel's eligible history ran out, so the same N messages cover
+        everything up to the end of the search window instead.
+        """
+        if len(messages) >= Config.MESSAGE_SEARCH_LIMIT:
+            span_ms = snowflake_to_timestamp_ms(messages[-1].id) - probe_ms
+        else:
+            span_ms = window_end_ms - probe_ms
+        observed = len(messages) / max(span_ms, 1)
+
+        state = self._channel_states.setdefault(channel.id, _ChannelState())
+        if state.density_per_ms is None:
+            state.density_per_ms = observed
+        else:
+            state.density_per_ms = DENSITY_EWMA_ALPHA * observed + (1 - DENSITY_EWMA_ALPHA) * state.density_per_ms
+        logger.debug(f"#{channel.name} density estimate is now {state.density_per_ms * DAY_MS:.1f} messages/day")
+
+    async def _first_in_window_ms(self, channel: discord.TextChannel, start_ms: int) -> int | None:
+        """Find the timestamp of the channel's first message at or after start_ms.
+
+        Costs one API call per channel, cached for the process lifetime. It only
+        re-probes when the advancing window start passes the cached first
+        message, or when a channel whose probe found nothing gets new traffic.
+        """
+        state = self._channel_states.setdefault(channel.id, _ChannelState())
+        valid, first_message_ms = state.cached_first_message(start_ms, channel.last_message_id)
+        if valid:
+            return first_message_ms
+
+        first = None
+        async for msg in channel.history(
+            after=discord.Object(id=timestamp_ms_to_snowflake(start_ms)),
+            limit=1,
+            oldest_first=True,
+        ):
+            first = msg
+
+        state.probed = True
+        state.probed_last_message_id = channel.last_message_id
+        state.first_message_ms = snowflake_to_timestamp_ms(first.id) if first is not None else None
+        return state.first_message_ms
 
     def _get_readable_channels(self, guild: discord.Guild) -> list[discord.TextChannel]:
         """Get list of text channels the bot can read."""

--- a/bot/services/message_selector.py
+++ b/bot/services/message_selector.py
@@ -23,15 +23,30 @@ MIN_BATCH_SIZE = 5
 
 DAY_MS = 24 * 60 * 60 * 1000
 
-# How quickly the per-channel density estimate follows new observations. Each
-# probe is noisy (activity varies over a channel's history), so blend rather
-# than replace.
-DENSITY_EWMA_ALPHA = 0.3
+# How quickly the per-channel density estimate follows new observations once
+# it has some history. Individual probes are very noisy (activity varies a lot
+# across a channel's history), so early observations are averaged outright
+# (alpha = 1/n), which converges on the true window-average density; after
+# ~1/alpha observations this becomes a slow EWMA so the estimate can still
+# track long-term changes in activity.
+DENSITY_EWMA_MIN_ALPHA = 0.1
+
+# Fraction of the channel-pick distribution dealt out uniformly regardless of
+# measured activity. This guarantees every channel keeps getting re-measured at
+# a bounded rate, so one unlucky near-zero reading can't bury a channel behind
+# busy neighbors for thousands of rounds.
+EXPLORATION_FRACTION = 0.1
 
 # Floor on the density used for channel weighting, equivalent to one message
-# per week. Without it a channel that once measured near-zero would never be
-# probed again and couldn't recover if it came back to life.
+# per week, mostly so the total weight can never degenerate to zero
 MIN_WEIGHT_DENSITY = 1 / (7 * DAY_MS)
+
+# How far the advancing window start may overtake a cached first-in-window
+# message before we re-probe for the real bound. Within the slack we just treat
+# the window start itself as the bound: the channel demonstrably had traffic
+# there, and at most this much dead time gets added to a window hundreds of
+# days long. Keeps re-probes to roughly one per channel per day of uptime.
+FIRST_MESSAGE_STALE_MS = DAY_MS
 
 
 @dataclass
@@ -43,8 +58,11 @@ class _ChannelState:
     it would complicate the privacy story for no real gain.
     """
 
-    # EWMA of messages per millisecond, measured around the points we've probed
+    # Estimate of messages per millisecond, measured around the points we've
+    # probed (a running mean that decays into a slow EWMA)
     density_per_ms: float | None = None
+    # How many probes have fed density_per_ms, for the 1/n averaging phase
+    observations: int = 0
     # Whether we've probed for the first in-window message yet; distinguishes
     # "never looked" from "looked and found nothing" (first_message_ms=None)
     probed: bool = False
@@ -60,14 +78,17 @@ class _ChannelState:
 
         Returns (cache_is_valid, first_message_ms). The lookback window only
         ever moves forward, so a cached first message stays correct until the
-        window start passes it; a cached "nothing in the window" stays correct
-        until the channel sees a new message.
+        window start passes it — and for FIRST_MESSAGE_STALE_MS beyond that we
+        still accept it (the caller clamps to the window start) rather than
+        re-probing every round for a channel with traffic right at the window
+        edge. A cached "nothing in the window" stays correct until the channel
+        sees a new message.
         """
         if not self.probed:
             return (False, None)
         if self.first_message_ms is None:
             return (last_message_id == self.probed_last_message_id, None)
-        return (self.first_message_ms >= start_ms, self.first_message_ms)
+        return (start_ms - self.first_message_ms <= FIRST_MESSAGE_STALE_MS, self.first_message_ms)
 
 
 def is_interesting_message(message: discord.Message) -> bool:
@@ -310,13 +331,13 @@ class MessageSelector:
                     return None
         return (start_ms, end_ms)
 
-    def _channel_weights(self, searchable: list[tuple[discord.TextChannel, tuple[int, int]]]) -> list[float]:
+    def _estimated_message_counts(self, searchable: list[tuple[discord.TextChannel, tuple[int, int]]]) -> list[float]:
         """Estimate how many eligible messages each channel holds.
 
-        A channel's weight is its measured message density times the span of
+        A channel's estimate is its measured message density times the span of
         its search window. Channels we haven't probed yet get the mean density
         of the ones we have, so the first round behaves like a uniform pick and
-        the weighting self-calibrates as probes accumulate.
+        the estimates self-calibrate as probes accumulate.
         """
         known = [
             state.density_per_ms
@@ -327,14 +348,29 @@ class MessageSelector:
             return [1.0] * len(searchable)
 
         default_density = sum(known) / len(known)
-        weights = []
+        counts = []
         for channel, (start_ms, end_ms) in searchable:
             state = self._channel_states.get(channel.id)
             density = (
                 state.density_per_ms if state is not None and state.density_per_ms is not None else default_density
             )
-            weights.append(max(density, MIN_WEIGHT_DENSITY) * (end_ms - start_ms + 1))
-        return weights
+            counts.append(max(density, MIN_WEIGHT_DENSITY) * (end_ms - start_ms + 1))
+        return counts
+
+    def _channel_weights(self, searchable: list[tuple[discord.TextChannel, tuple[int, int]]]) -> list[float]:
+        """Weight channels by estimated eligible-message count, plus exploration.
+
+        Mixing a uniform component into the activity-proportional weights keeps
+        every channel's density estimate fresh: without it, a channel that once
+        measured near-zero would almost never be picked again, so the estimate
+        could never correct itself.
+        """
+        counts = self._estimated_message_counts(searchable)
+        total = sum(counts)
+        if total <= 0:
+            return [1.0] * len(searchable)
+        uniform_share = EXPLORATION_FRACTION * total / len(counts)
+        return [(1 - EXPLORATION_FRACTION) * count + uniform_share for count in counts]
 
     def _observe_density(
         self, channel: discord.TextChannel, probe_ms: int, window_end_ms: int, messages: list[discord.Message]
@@ -345,6 +381,11 @@ class MessageSelector:
         the probe point and the last message's timestamp. A short batch means
         the channel's eligible history ran out, so the same N messages cover
         everything up to the end of the search window instead.
+
+        Because probe points are uniform over the search window, each
+        observation is an unbiased (if noisy) sample of the channel's average
+        density, and averaging them converges on the true value even for very
+        bursty channels.
         """
         if len(messages) >= Config.MESSAGE_SEARCH_LIMIT:
             span_ms = snowflake_to_timestamp_ms(messages[-1].id) - probe_ms
@@ -353,18 +394,20 @@ class MessageSelector:
         observed = len(messages) / max(span_ms, 1)
 
         state = self._channel_states.setdefault(channel.id, _ChannelState())
-        if state.density_per_ms is None:
-            state.density_per_ms = observed
-        else:
-            state.density_per_ms = DENSITY_EWMA_ALPHA * observed + (1 - DENSITY_EWMA_ALPHA) * state.density_per_ms
+        state.observations += 1
+        alpha = max(1 / state.observations, DENSITY_EWMA_MIN_ALPHA)
+        previous = state.density_per_ms if state.density_per_ms is not None else 0.0
+        state.density_per_ms = alpha * observed + (1 - alpha) * previous
         logger.debug(f"#{channel.name} density estimate is now {state.density_per_ms * DAY_MS:.1f} messages/day")
 
     async def _first_in_window_ms(self, channel: discord.TextChannel, start_ms: int) -> int | None:
         """Find the timestamp of the channel's first message at or after start_ms.
 
-        Costs one API call per channel, cached for the process lifetime. It only
-        re-probes when the advancing window start passes the cached first
-        message, or when a channel whose probe found nothing gets new traffic.
+        Costs roughly one API call per channel: the result is cached, and only
+        re-probed when the advancing window start overtakes the cached first
+        message by more than FIRST_MESSAGE_STALE_MS (about once per channel per
+        day of uptime, for channels with traffic right at the window edge), or
+        when a channel whose probe found nothing gets new traffic.
         """
         state = self._channel_states.setdefault(channel.id, _ChannelState())
         valid, first_message_ms = state.cached_first_message(start_ms, channel.last_message_id)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -164,13 +164,12 @@ This implementation covers Phase 1 (MVP):
 - Basic game commands
 - SQLite database
 - Real-time message indexing (no historical backfill)
-- Equal channel weights for random selection
+- Activity-weighted channel selection (density estimates calibrated from history probes, kept in memory)
 - Basic scoring system
 - Leaderboard
 
 ### Not Included in MVP
 
-- Channel activity weighting
 - Historical message backfill
 - Configurable interest criteria
 - Multi-round games

--- a/tests/test_message_selector.py
+++ b/tests/test_message_selector.py
@@ -1,5 +1,6 @@
 """Tests for message selector."""
 
+import itertools
 import logging
 import time
 from datetime import datetime, timedelta, timezone
@@ -9,7 +10,14 @@ from unittest.mock import MagicMock
 import discord
 import pytest
 
-from bot.services.message_selector import URL_PATTERN, MessageSelector, is_interesting_message
+from bot.services.message_selector import (
+    DENSITY_EWMA_ALPHA,
+    MIN_WEIGHT_DENSITY,
+    URL_PATTERN,
+    MessageSelector,
+    _ChannelState,
+    is_interesting_message,
+)
 from config import Config
 from utils.snowflake import snowflake_to_timestamp_ms, timestamp_ms_to_snowflake
 
@@ -85,6 +93,8 @@ class TestIsInterestingMessage:
 class MockChannel:
     """A text channel whose history() returns a fixed list of messages."""
 
+    _next_id = itertools.count(1000)
+
     def __init__(
         self,
         name="general",
@@ -95,7 +105,7 @@ class MockChannel:
         empty=False,
     ):
         self.name = name
-        self.id = 999
+        self.id = next(MockChannel._next_id)
         self._messages = messages or []
         self._forbidden_after = forbidden_after
         now_ms = int(time.time() * 1000)
@@ -108,10 +118,13 @@ class MockChannel:
         self.last_message_id = None if empty else timestamp_ms_to_snowflake(last_message_ms)
         self.history_calls = []
         self.before_calls = []
+        self.limit_calls = []
 
-    def history(self, *, after, before, limit, oldest_first):
+    def history(self, *, after, before=None, limit, oldest_first):
         self.history_calls.append(after.id)
-        self.before_calls.append(before.id)
+        if before is not None:
+            self.before_calls.append(before.id)
+        self.limit_calls.append(limit)
         messages = self._messages
         forbid = self._forbidden_after is not None and len(self.history_calls) > self._forbidden_after
 
@@ -122,6 +135,11 @@ class MockChannel:
                 yield msg
 
         return _iter()
+
+    @property
+    def batch_calls(self):
+        """The `after` ids of full history fetches, excluding limit-1 probes."""
+        return [after for after, limit in zip(self.history_calls, self.limit_calls, strict=True) if limit > 1]
 
     def permissions_for(self, _member):
         class Permissions:
@@ -308,8 +326,10 @@ class TestSelectRandomMessage:
     async def test_falls_back_when_channel_becomes_unreadable(self, mock_discord_message):
         # Only interesting message was used recently, then the bot loses access to
         # the guild's only channel. The already-fetched fallback should still be used.
+        # Call 1 is the first-in-window probe, call 2 the batch that sets the
+        # fallback; access is lost after that.
         messages = make_messages(mock_discord_message, 10, interesting_ids={4})
-        channel = MockChannel(messages=messages, forbidden_after=1)
+        channel = MockChannel(messages=messages, forbidden_after=2)
 
         result = await MessageSelector().select_random_message(as_guild(channel), exclude_message_ids={"4"})
 
@@ -363,3 +383,182 @@ class TestSelectRandomMessage:
 
         assert await MessageSelector().select_random_message(guild) is None
         assert too_new.history_calls == []
+
+    @pytest.mark.asyncio
+    async def test_busy_channels_get_picked_more_often(self, mock_discord_message, monkeypatch):
+        now_ms = int(time.time() * 1000)
+        quiet = MockChannel(name="quiet", messages=make_messages(mock_discord_message, 10, interesting_ids={0}))
+        busy = MockChannel(name="busy", messages=make_messages(mock_discord_message, 10, interesting_ids={0}))
+        selector = MessageSelector()
+        # Pretend earlier probes established a 1000x activity difference, and
+        # freeze the estimates so the mocks' batches don't recalibrate them
+        for channel, messages_per_day in ((quiet, 1), (busy, 1000)):
+            selector._channel_states[channel.id] = _ChannelState(
+                density_per_ms=messages_per_day / DAY_MS,
+                probed=True,
+                first_message_ms=now_ms - 300 * DAY_MS,
+                probed_last_message_id=channel.last_message_id,
+            )
+        monkeypatch.setattr(selector, "_observe_density", lambda *args: None)
+
+        for _ in range(200):
+            assert await selector.select_random_message(as_guild(quiet, busy)) is not None
+
+        # Expected split is ~1000:1; leave lots of slack for randomness
+        assert len(busy.batch_calls) > 180
+        assert len(quiet.batch_calls) < 20
+
+
+class TestChannelWeights:
+    def test_uniform_before_any_observations(self):
+        a, b = MockChannel(name="a"), MockChannel(name="b")
+        searchable = [(as_channel(a), (0, 100)), (as_channel(b), (0, 10**12))]
+
+        assert MessageSelector()._channel_weights(searchable) == [1.0, 1.0]
+
+    def test_weights_scale_with_density(self):
+        a, b = MockChannel(name="a"), MockChannel(name="b")
+        selector = MessageSelector()
+        selector._channel_states[a.id] = _ChannelState(density_per_ms=0.001)
+        selector._channel_states[b.id] = _ChannelState(density_per_ms=0.002)
+        span = 10 * DAY_MS
+
+        weight_a, weight_b = selector._channel_weights([(as_channel(a), (0, span)), (as_channel(b), (0, span))])
+
+        assert weight_b == pytest.approx(2 * weight_a)
+
+    def test_weights_scale_with_window_span(self):
+        a = MockChannel(name="a")
+        selector = MessageSelector()
+        selector._channel_states[a.id] = _ChannelState(density_per_ms=0.001)
+
+        [narrow] = selector._channel_weights([(as_channel(a), (0, 10 * DAY_MS))])
+        [wide] = selector._channel_weights([(as_channel(a), (0, 20 * DAY_MS))])
+
+        assert wide == pytest.approx(2 * narrow, rel=1e-3)
+
+    def test_unknown_channel_gets_mean_of_known_densities(self):
+        a, b, c = MockChannel(name="a"), MockChannel(name="b"), MockChannel(name="c")
+        selector = MessageSelector()
+        selector._channel_states[a.id] = _ChannelState(density_per_ms=0.001)
+        selector._channel_states[b.id] = _ChannelState(density_per_ms=0.003)
+        span = 10 * DAY_MS
+
+        weight_a, weight_b, weight_c = selector._channel_weights([(as_channel(ch), (0, span)) for ch in (a, b, c)])
+
+        assert weight_c == pytest.approx((weight_a + weight_b) / 2)
+
+    def test_dead_channel_weight_is_floored_above_zero(self):
+        dead, busy = MockChannel(name="dead"), MockChannel(name="busy")
+        selector = MessageSelector()
+        selector._channel_states[dead.id] = _ChannelState(density_per_ms=0.0)
+        selector._channel_states[busy.id] = _ChannelState(density_per_ms=1.0)
+        span = 10 * DAY_MS
+
+        weight_dead, _ = selector._channel_weights([(as_channel(dead), (0, span)), (as_channel(busy), (0, span))])
+
+        assert weight_dead == pytest.approx(MIN_WEIGHT_DENSITY * (span + 1))
+        assert weight_dead > 0
+
+
+class TestObserveDensity:
+    def test_full_batch_measures_probe_to_last_message(self, mock_discord_message):
+        now_ms = int(time.time() * 1000)
+        probe_ms = now_ms - 10 * DAY_MS
+        last_ms = now_ms - 5 * DAY_MS
+        count = Config.MESSAGE_SEARCH_LIMIT
+        messages = [mock_discord_message(content="x", message_id=timestamp_ms_to_snowflake(last_ms))] * count
+        channel = MockChannel()
+        selector = MessageSelector()
+
+        selector._observe_density(as_channel(channel), probe_ms, now_ms - DAY_MS, messages)
+
+        assert selector._channel_states[channel.id].density_per_ms == pytest.approx(count / (5 * DAY_MS))
+
+    def test_short_batch_measures_probe_to_window_end(self, mock_discord_message):
+        now_ms = int(time.time() * 1000)
+        probe_ms = now_ms - 21 * DAY_MS
+        window_end_ms = now_ms - DAY_MS
+        messages = [mock_discord_message(content="x", message_id=timestamp_ms_to_snowflake(now_ms - 15 * DAY_MS))] * 10
+        channel = MockChannel()
+        selector = MessageSelector()
+
+        selector._observe_density(as_channel(channel), probe_ms, window_end_ms, messages)
+
+        # The batch ran out before the limit, so those 10 messages are all
+        # there is between the probe point and the end of the window
+        assert selector._channel_states[channel.id].density_per_ms == pytest.approx(10 / (20 * DAY_MS))
+
+    def test_observations_blend_as_an_ewma(self, mock_discord_message):
+        now_ms = int(time.time() * 1000)
+        window_end_ms = now_ms - DAY_MS
+        channel = MockChannel()
+        selector = MessageSelector()
+
+        selector._observe_density(as_channel(channel), window_end_ms - 10 * DAY_MS, window_end_ms, [])
+        assert selector._channel_states[channel.id].density_per_ms == 0.0
+
+        messages = [mock_discord_message(content="x", message_id=timestamp_ms_to_snowflake(window_end_ms))] * 10
+        selector._observe_density(as_channel(channel), window_end_ms - 10 * DAY_MS, window_end_ms, messages)
+
+        expected = DENSITY_EWMA_ALPHA * (10 / (10 * DAY_MS))
+        assert selector._channel_states[channel.id].density_per_ms == pytest.approx(expected)
+
+
+class TestFirstInWindowProbe:
+    @pytest.mark.asyncio
+    async def test_probe_is_cached_and_narrows_the_search(self, mock_discord_message):
+        # Channel created 400 days ago, but all its traffic is from the last month
+        now_ms = int(time.time() * 1000)
+        first_ms = now_ms - 30 * DAY_MS
+        last_ms = now_ms - 3 * DAY_MS
+        messages = [
+            mock_discord_message(content="A" * 200, message_id=timestamp_ms_to_snowflake(first_ms + i * DAY_MS))
+            for i in range(28)
+        ]
+        channel = MockChannel(messages=messages, created_ms=now_ms - 400 * DAY_MS, last_message_ms=last_ms)
+        selector = MessageSelector()
+
+        for _ in range(20):
+            assert await selector.select_random_message(as_guild(channel)) is not None
+
+        # Exactly one limit-1 probe ever, and every batch fetch starts at or
+        # after the channel's real first in-window message rather than at its
+        # creation 400 days ago
+        assert channel.limit_calls.count(1) == 1
+        assert channel.batch_calls
+        assert all(after >= timestamp_ms_to_snowflake(first_ms - 1000) for after in channel.batch_calls)
+
+    @pytest.mark.asyncio
+    async def test_channel_with_only_deleted_history_is_probed_once(self):
+        # last_message_id points at a message, but everything in the window has
+        # been deleted, so history() comes back empty
+        channel = MockChannel(messages=[])
+        selector = MessageSelector()
+
+        assert await selector.select_random_message(as_guild(channel)) is None
+        assert channel.limit_calls == [1]
+
+        # The empty result is remembered: the second call doesn't touch the API
+        assert await selector.select_random_message(as_guild(channel)) is None
+        assert channel.limit_calls == [1]
+
+    @pytest.mark.asyncio
+    async def test_reprobes_when_an_empty_channel_gets_new_traffic(self, mock_discord_message):
+        now_ms = int(time.time() * 1000)
+        channel = MockChannel(messages=[])
+        selector = MessageSelector()
+
+        assert await selector.select_random_message(as_guild(channel)) is None
+
+        # New messages arrive, which moves last_message_id forward
+        channel._messages = [
+            mock_discord_message(content="A" * 200, message_id=timestamp_ms_to_snowflake(now_ms - (10 - i) * DAY_MS))
+            for i in range(8)
+        ]
+        channel.last_message_id = channel._messages[-1].id
+
+        result = await selector.select_random_message(as_guild(channel))
+
+        assert result is not None
+        assert channel.limit_calls.count(1) == 2

--- a/tests/test_message_selector.py
+++ b/tests/test_message_selector.py
@@ -11,8 +11,8 @@ import discord
 import pytest
 
 from bot.services.message_selector import (
-    DENSITY_EWMA_ALPHA,
-    MIN_WEIGHT_DENSITY,
+    DENSITY_EWMA_MIN_ALPHA,
+    EXPLORATION_FRACTION,
     URL_PATTERN,
     MessageSelector,
     _ChannelState,
@@ -404,9 +404,10 @@ class TestSelectRandomMessage:
         for _ in range(200):
             assert await selector.select_random_message(as_guild(quiet, busy)) is not None
 
-        # Expected split is ~1000:1; leave lots of slack for randomness
-        assert len(busy.batch_calls) > 180
-        assert len(quiet.batch_calls) < 20
+        # Expected split is ~1000:1 plus the 10% uniform exploration mix, so
+        # quiet should get roughly 5% of picks; leave lots of slack
+        assert len(busy.batch_calls) > 170
+        assert len(quiet.batch_calls) < 30
 
 
 class TestChannelWeights:
@@ -416,24 +417,24 @@ class TestChannelWeights:
 
         assert MessageSelector()._channel_weights(searchable) == [1.0, 1.0]
 
-    def test_weights_scale_with_density(self):
+    def test_counts_scale_with_density(self):
         a, b = MockChannel(name="a"), MockChannel(name="b")
         selector = MessageSelector()
         selector._channel_states[a.id] = _ChannelState(density_per_ms=0.001)
         selector._channel_states[b.id] = _ChannelState(density_per_ms=0.002)
         span = 10 * DAY_MS
 
-        weight_a, weight_b = selector._channel_weights([(as_channel(a), (0, span)), (as_channel(b), (0, span))])
+        count_a, count_b = selector._estimated_message_counts([(as_channel(a), (0, span)), (as_channel(b), (0, span))])
 
-        assert weight_b == pytest.approx(2 * weight_a)
+        assert count_b == pytest.approx(2 * count_a)
 
-    def test_weights_scale_with_window_span(self):
+    def test_counts_scale_with_window_span(self):
         a = MockChannel(name="a")
         selector = MessageSelector()
         selector._channel_states[a.id] = _ChannelState(density_per_ms=0.001)
 
-        [narrow] = selector._channel_weights([(as_channel(a), (0, 10 * DAY_MS))])
-        [wide] = selector._channel_weights([(as_channel(a), (0, 20 * DAY_MS))])
+        [narrow] = selector._estimated_message_counts([(as_channel(a), (0, 10 * DAY_MS))])
+        [wide] = selector._estimated_message_counts([(as_channel(a), (0, 20 * DAY_MS))])
 
         assert wide == pytest.approx(2 * narrow, rel=1e-3)
 
@@ -444,21 +445,42 @@ class TestChannelWeights:
         selector._channel_states[b.id] = _ChannelState(density_per_ms=0.003)
         span = 10 * DAY_MS
 
-        weight_a, weight_b, weight_c = selector._channel_weights([(as_channel(ch), (0, span)) for ch in (a, b, c)])
+        count_a, count_b, count_c = selector._estimated_message_counts(
+            [(as_channel(ch), (0, span)) for ch in (a, b, c)]
+        )
 
-        assert weight_c == pytest.approx((weight_a + weight_b) / 2)
+        assert count_c == pytest.approx((count_a + count_b) / 2)
 
-    def test_dead_channel_weight_is_floored_above_zero(self):
+    def test_weights_mix_in_a_uniform_exploration_share(self):
         dead, busy = MockChannel(name="dead"), MockChannel(name="busy")
         selector = MessageSelector()
         selector._channel_states[dead.id] = _ChannelState(density_per_ms=0.0)
         selector._channel_states[busy.id] = _ChannelState(density_per_ms=1.0)
         span = 10 * DAY_MS
+        searchable = [(as_channel(dead), (0, span)), (as_channel(busy), (0, span))]
 
-        weight_dead, _ = selector._channel_weights([(as_channel(dead), (0, span)), (as_channel(busy), (0, span))])
+        weight_dead, weight_busy = selector._channel_weights(searchable)
 
-        assert weight_dead == pytest.approx(MIN_WEIGHT_DENSITY * (span + 1))
-        assert weight_dead > 0
+        # However dead a channel measures, it keeps at least half the uniform
+        # exploration share, so its estimate can still be corrected later
+        assert weight_dead / (weight_dead + weight_busy) >= EXPLORATION_FRACTION / 2
+        # And exploration barely dilutes the activity signal for busy channels
+        assert weight_busy / (weight_dead + weight_busy) >= 0.9
+
+    def test_weights_preserve_count_proportions_beyond_exploration(self):
+        a, b = MockChannel(name="a"), MockChannel(name="b")
+        selector = MessageSelector()
+        selector._channel_states[a.id] = _ChannelState(density_per_ms=0.001)
+        selector._channel_states[b.id] = _ChannelState(density_per_ms=0.002)
+        span = 10 * DAY_MS
+        searchable = [(as_channel(a), (0, span)), (as_channel(b), (0, span))]
+
+        count_a, count_b = selector._estimated_message_counts(searchable)
+        weight_a, weight_b = selector._channel_weights(searchable)
+        total = count_a + count_b
+
+        assert weight_a == pytest.approx((1 - EXPLORATION_FRACTION) * count_a + EXPLORATION_FRACTION * total / 2)
+        assert weight_b == pytest.approx((1 - EXPLORATION_FRACTION) * count_b + EXPLORATION_FRACTION * total / 2)
 
 
 class TestObserveDensity:
@@ -489,7 +511,9 @@ class TestObserveDensity:
         # there is between the probe point and the end of the window
         assert selector._channel_states[channel.id].density_per_ms == pytest.approx(10 / (20 * DAY_MS))
 
-    def test_observations_blend_as_an_ewma(self, mock_discord_message):
+    def test_early_observations_average_evenly(self, mock_discord_message):
+        # With few observations alpha is 1/n, so two probes average 50/50
+        # rather than letting the newest one dominate
         now_ms = int(time.time() * 1000)
         window_end_ms = now_ms - DAY_MS
         channel = MockChannel()
@@ -501,7 +525,22 @@ class TestObserveDensity:
         messages = [mock_discord_message(content="x", message_id=timestamp_ms_to_snowflake(window_end_ms))] * 10
         selector._observe_density(as_channel(channel), window_end_ms - 10 * DAY_MS, window_end_ms, messages)
 
-        expected = DENSITY_EWMA_ALPHA * (10 / (10 * DAY_MS))
+        expected = (0.0 + 10 / (10 * DAY_MS)) / 2
+        assert selector._channel_states[channel.id].density_per_ms == pytest.approx(expected)
+
+    def test_established_estimates_decay_as_a_slow_ewma(self, mock_discord_message):
+        now_ms = int(time.time() * 1000)
+        window_end_ms = now_ms - DAY_MS
+        channel = MockChannel()
+        selector = MessageSelector()
+        prior = 42 / DAY_MS
+        selector._channel_states[channel.id] = _ChannelState(density_per_ms=prior, observations=100)
+
+        messages = [mock_discord_message(content="x", message_id=timestamp_ms_to_snowflake(window_end_ms))] * 10
+        selector._observe_density(as_channel(channel), window_end_ms - 10 * DAY_MS, window_end_ms, messages)
+
+        observed = 10 / (10 * DAY_MS)
+        expected = DENSITY_EWMA_MIN_ALPHA * observed + (1 - DENSITY_EWMA_MIN_ALPHA) * prior
         assert selector._channel_states[channel.id].density_per_ms == pytest.approx(expected)
 
 
@@ -561,4 +600,30 @@ class TestFirstInWindowProbe:
         result = await selector.select_random_message(as_guild(channel))
 
         assert result is not None
+        assert channel.limit_calls.count(1) == 2
+
+    @pytest.mark.asyncio
+    async def test_reprobes_when_window_advances_past_first_message(self, mock_discord_message, monkeypatch):
+        # Traffic starts right at the window edge, the worst case for the
+        # cache: the advancing window start overtakes the cached first message
+        real_now_s = time.time()
+        now_ms = int(real_now_s * 1000)
+        window_start_ms = now_ms - Config.LOOKBACK_DAYS * DAY_MS
+        messages = [
+            mock_discord_message(
+                content="A" * 200, message_id=timestamp_ms_to_snowflake(window_start_ms + 60_000 + i * DAY_MS)
+            )
+            for i in range(10)
+        ]
+        channel = MockChannel(messages=messages)
+        selector = MessageSelector()
+
+        for _ in range(5):
+            assert await selector.select_random_message(as_guild(channel)) is not None
+        assert channel.limit_calls.count(1) == 1
+
+        # Two days later the window start is beyond the staleness slack, so
+        # the bound gets re-measured
+        monkeypatch.setattr(time, "time", lambda: real_now_s + 2 * 24 * 60 * 60)
+        assert await selector.select_random_message(as_guild(channel)) is not None
         assert channel.limit_calls.count(1) == 2


### PR DESCRIPTION
Fixes #29 (follow-up to #28).

## Problem

`select_random_message` picked channels uniformly, so a dead channel with 3 interesting messages all year got the same weight as the busiest channel in the server. On guilds with many quiet channels, a disproportionate share of rounds came from tiny message pools — the remaining cause of repeats.

## Changes

Both pieces are backed by a new in-memory `_ChannelState` per channel on the selector:

**Density-weighted channel selection.** Every history batch we already fetch doubles as a free density measurement: N messages over the observed span (probe point → last message for a full batch, probe point → window end for a short one). Since probe points are uniform over the search window, each observation is an unbiased (if noisy) sample of the channel's average density, so they're averaged outright while the estimate is young (α = 1/n) and decay into a slow EWMA (α = 0.1) that can still track long-term activity changes. Channel picking switches from `random.choice` to `random.choices` weighted by `density × window span` — the estimated count of eligible messages — so every *message* in the guild is roughly equally likely rather than every *channel*. Robustness details:

- Channels with no density estimate yet get the mean of the known ones, so the first round behaves exactly like the old uniform pick.
- 10% of the pick distribution is dealt out uniformly regardless of measured activity, so every channel keeps getting re-measured at a bounded rate and one unlucky near-zero reading can't bury a channel behind busy neighbors.

**First-in-window probe.** #28 clamped the search window to `[channel.created_at, last_message_id]`, which fixed young channels, but a channel created two years ago whose traffic is all recent still had most draws landing before its first in-window message and collapsing onto its oldest messages. A single `history(after=window_start, limit=1, oldest_first=True)` call finds the real lower bound. The result is cached and tolerates a day of staleness as the lookback window advances (clamping to the window start in the meantime, which adds at most a day of dead time to a window hundreds of days long); it's re-probed when the window start overtakes the cached first message by more than that, or when a channel whose probe found nothing gets new traffic (detected via `last_message_id`). The cached bound also tightens the window span used for weighting, so dormant-then-active channels aren't overweighted by their empty years.

## API cost

Roughly one extra API call per channel (the first-in-window probe), re-probed at most about once per channel per day of process uptime. Density estimates cost nothing — they reuse batches we were already fetching.

## Privacy

I went with in-memory state rather than a DB table: it's all derived from message timestamps we already fetch, rebuilds within a few rounds after a restart, and storing nothing means **no privacy policy update is needed**. If we later want it to survive restarts we can add a table and a policy line then.

## Validation

The estimator design was checked by simulation (see the review-fix commit): for a bursty "seasonal" channel holding ~74% of a guild's eligible messages next to a steady quiet channel, a naive α=0.3 EWMA gave it only 33–50% of picks (worse than uniform); the mean-then-slow-EWMA estimator with the exploration mix gives ~69%.

## Testing

- Unit tests for count estimation (uniform before observations, scales with density and span, mean-density default), the exploration mix, the density estimator (full-batch vs short-batch spans, 1/n averaging, slow-EWMA steady state), and the probe (caches, narrows the search window, remembers empty channels, re-probes on new traffic and — via a clock-advancing test — on window-start staleness).
- A statistical test that a channel with 1000× the measured density receives ~95% of the picks.
- All 167 tests pass; ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)